### PR TITLE
Fix 64-bit to 32-bit integer conversion

### DIFF
--- a/src/google/protobuf/compiler/cpp/parse_function_generator.cc
+++ b/src/google/protobuf/compiler/cpp/parse_function_generator.cc
@@ -1371,7 +1371,7 @@ void ParseFunctionGenerator::GenerateFieldBody(
         format.Set("enum_type",
                    QualifiedClassName(field->enum_type(), options_));
         format(
-            "$uint64$ val = ::$proto_ns$::internal::ReadVarint64(&ptr);\n"
+            "$int32$ val = ::$proto_ns$::internal::ReadVarint32(&ptr);\n"
             "CHK_(ptr);\n");
         if (!HasPreservingUnknownEnumSemantics(field)) {
           format("if (PROTOBUF_PREDICT_TRUE($enum_type$_IsValid(val))) {\n");


### PR DESCRIPTION
In a check for whether a value is valid for enum, protobuf loads the integer value as a 64 bit int, then calls `EnumType_IsValid(value)`. But `value` is a `int` parameter, so this triggers warnings (promoted to error, since this is in generated code, not in library source, and we use -Werror in the main repo). The enum is already declared as `enum EnumType : int`, so load the integer value as 32 bit instead.