### PR TITLE
Remove unnecessary copy in SetAllocated in !NDEBUG

### DIFF
--- a/src/google/protobuf/arenastring.cc
+++ b/src/google/protobuf/arenastring.cc
@@ -204,14 +204,6 @@ void ArenaStringPtr::SetAllocated(std::string* value, Arena* arena) {
   if (value == nullptr) {
     InitDefault();
   } else {
-#ifndef NDEBUG
-    // On debug builds, copy the string so the address differs.  delete will
-    // fail if value was a stack-allocated temporary/etc., which would have
-    // failed when arena ran its cleanup list.
-    std::string* new_value = new std::string(std::move(*value));
-    delete value;
-    value = new_value;
-#endif  // !NDEBUG
     InitAllocated(value, arena);
   }
 }


### PR DESCRIPTION
In `ArenaStringPtr::SetAllocated`, if not compiling with NDEBUG, there is an extra step where a new `std::string` is allocated on the heap as a copy of the parameter, and the parameter is immediately deleted. This is present to try to catch bugs earlier, since the passed in `std::string` will be `delete`d when the message is destroyed. But our use of `SetAllocated` (via the `set_allocated_*()` generated methods) in some places is to set it to a `std::string` allocated on the stack, then call `release_*()` to ensure that it is never `delete`d.

This removes that extra step.